### PR TITLE
Add entries for KiCad files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,47 @@
 *.b#*
 *.s#*
 *~
+
+# KiCad .gitignore fetched on 2026-03-19 from
+# https://github.com/github/gitignore/blob/main/KiCad.gitignore
+
+# For PCBs designed using KiCad: https://www.kicad.org/
+# Format documentation: https://kicad.org/help/file-formats/
+
+# Temporary files
+*.000
+*.bak
+*.bck
+*.kicad_pcb-bak
+*.kicad_sch-bak
+*-backups
+*-cache*
+*-bak
+*-bak*
+*~
+~*
+_autosave-*
+\#auto_saved_files\#
+*.tmp
+*-save.pro
+*-save.kicad_pcb
+fp-info-cache
+~*.lck
+\#auto_saved_files#
+
+# Netlist files (exported from Eeschema)
+*.net
+
+# Autorouter files (exported from Pcbnew)
+*.dsn
+*.ses
+
+# Exported BOM files
+*.xml
+*.csv
+
+# Archived Backups (KiCad 6.0)
+**/*-backups/*.zip
+
+# Local project settings
+*.kicad_prl


### PR DESCRIPTION
This PR adds entries for KiCad files to the repositories `.gitignore`.

KiCad `.gitignore` entries were fetched on 2026-03-19 from https://github.com/github/gitignore/blob/main/KiCad.gitignore